### PR TITLE
Fix some indentation of code in Scala cheat sheet

### DIFF
--- a/CheatSheet.md
+++ b/CheatSheet.md
@@ -71,7 +71,7 @@ single argument that returns another function.
       val nb3 = x + y                         // computed only once  
       override def toString =                 // overridden method  
           member1 + ", " + member2 
-      }
+    }
 
     new MyClass(1, 2) // creates a new object of type
 ```
@@ -104,7 +104,7 @@ Note that assignment operators have lowest precedence. (Read Scala Language Spec
 
 ## Class hierarchies
 ```scala
-    abstract class TopLevel {     // abstract class  
+    abstract class TopLevel {    // abstract class  
       def method1(x: Int): Int   // abstract method  
       def method2(x: Int): Int = { ... }  
     }


### PR DESCRIPTION
The `}` belongs to the end of the `class`, not to the end of `def toString`

And the “abstract class” comment was arbitrarily at a different distance from the text from the “abstract method” comment. Either they should both be normal comments, with one space, or aligned. Since they were aligned weirdly, they were probably meant to be aligned, but the code earlier on the line was edited and that threw them off.
