### PR TITLE
Clarify behavior in Higher Order Function example

### DIFF
--- a/CheatSheet.md
+++ b/CheatSheet.md
@@ -35,7 +35,7 @@ These are functions that take a function as a parameter or return functions.
 ```scala
     // sum() returns a function that takes two integers and returns an integer  
     def sum(f: Int => Int): (Int, Int) => Int = {  
-      def sumf(a: Int, b: Int): Int = {...}  
+      def sumf(a: Int, b: Int): Int = f(a) + f(b)  
       sumf  
     } 
     
@@ -47,7 +47,7 @@ These are functions that take a function as a parameter or return functions.
     sum(x => x * x * x)                 // Same anonymous function with type inferred
 
     def cube(x: Int) = x * x * x  
-    sum(x => x * x * x)(1, 10) // sum of cubes from 1 to 10
+    sum(x => x * x * x)(1, 10) // sum of 1 cubed and 10 cubed
     sum(cube)(1, 10)           // same as above      
 ```
 


### PR DESCRIPTION
This PR is provided as a suggestion to clarify the example in the section for Higher Order Functions. I am open to feedback and appreciate you supporting such a fantastic resource!

The first code example:

```
def sum(f: Int => Int): (Int, Int) => Int = {
  def sumf(a: Int, b: Int): Int = {...}
  sumf
}
```

Is later used as:

```
sum(x => x * x * x)(1, 10) // sum of cubes from 1 to 10
```

The behavior in `sum` appears to be that `sum` accepts a function that will be applied to each element, then the result summed (addition). The way the comment is constructed in this example, it feels like there is a lot more going on, that is, the range from 1 to 10 is utilized and then each of those values is cubed and summed (pairwise perhaps? This is the confusing part - how does the returned function of `(Int, Int) => Int` work for this range concept?).

The implementation for `sumf` suggested in this PR attempts to remove this point of confusion and simplify the example by adding a concrete implementation and modifying the corresponding comment to more precisely match that behavior.
