### PR TITLE
updates links to scaladoc

### DIFF
--- a/CheatSheet.md
+++ b/CheatSheet.md
@@ -281,22 +281,26 @@ Instead of `p => p match { case ... }`, you can simply write `{case ...}`, so th
 Scala defines several collection classes:
 
 ### Base Classes
-- [`Iterable`](http://www.scala-lang.org/api/current/index.html#scala.collection.Iterable) (collections you can iterate on)
-- [`Seq`](http://www.scala-lang.org/api/current/index.html#scala.collection.Seq) (ordered sequences)
-- [`Set`](http://www.scala-lang.org/api/current/index.html#scala.collection.Set)
-- [`Map`](http://www.scala-lang.org/api/current/index.html#scala.collection.Map) (lookup data structure)
+
+- [`Iterable`](https://www.scala-lang.org/api/current/scala/collection/Iterable.html) (collections you can iterate on)
+- [`Seq`](https://www.scala-lang.org/api/current/scala/collection/Seq.html) (ordered sequences)
+- [`Set`](https://www.scala-lang.org/api/current/scala/collection/Set.html)
+- [`Map`](https://www.scala-lang.org/api/current/scala/collection/Map.html) (lookup data structure)
 
 ### Immutable Collections
-- [`List`](http://www.scala-lang.org/api/current/index.html#scala.collection.immutable.List) (linked list, provides fast sequential access)
-- [`Stream`](http://www.scala-lang.org/api/current/index.html#scala.collection.immutable.Stream) (same as List, except that the tail is evaluated only on demand)
-- [`Vector`](http://www.scala-lang.org/api/current/index.html#scala.collection.immutable.Vector) (array-like type, implemented as tree of blocks, provides fast random access)
-- [`Range`](http://www.scala-lang.org/api/current/index.html#scala.collection.immutable.Range) (ordered sequence of integers with equal spacing)
+
+- [`List`](https://www.scala-lang.org/api/current/scala/collection/immutable/List.html) (linked list, provides fast sequential access)
+- [`Stream`](https://www.scala-lang.org/api/current/scala/collection/immutable/Stream.html) (same as List, except that the tail is evaluated only on demand)
+- [`Vector`](https://www.scala-lang.org/api/current/scala/collection/immutable/Vector.html) (array-like type, implemented as tree of blocks, provides fast random access)
+- [`Range`](https://www.scala-lang.org/api/current/scala/collection/immutable/Range.html) (ordered sequence of integers with equal spacing)
 - [`String`](http://docs.oracle.com/javase/1.5.0/docs/api/java/lang/String.html) (Java type, implicitly converted to a character sequence, so you can treat every string like a `Seq[Char]`)
-- [`Map`](http://www.scala-lang.org/api/current/index.html#scala.collection.immutable.Map) (collection that maps keys to values)
-- [`Set`](http://www.scala-lang.org/api/current/index.html#scala.collection.immutable.Set) (collection without duplicate elements)
+- [`Map`](https://www.scala-lang.org/api/current/scala/collection/immutable/Map.html) (collection that maps keys to values)
+- [`Set`](https://www.scala-lang.org/api/current/scala/collection/immutable/Set.html) (collection without duplicate elements)
 
 ### Mutable Collections
-- [`Array`](http://www.scala-lang.org/api/current/index.html#scala.Array) (Scala arrays are native JVM arrays at runtime, therefore they are very performant)
+Most of the immutable collections above have a mutable counterpart, e.g.: 
+
+- [`Array`](https://www.scala-lang.org/api/current/scala/Array.html) (Scala arrays are native JVM arrays at runtime, therefore they are very performant)
 - Scala also has mutable maps and sets; these should only be used if there are performance issues with immutable types
 
 ### Examples


### PR DESCRIPTION
Thanks for the cheat sheet! I have been linked to it from the "EPFL programming reactive systems"  edx class, which has just started now. 

I noticed some dead links to scaladoc, hopefully this PR solves that. 