### PR TITLE
Update Twitter Scala School domain to prevent 404

### DIFF
--- a/LearningResources.md
+++ b/LearningResources.md
@@ -6,7 +6,7 @@ title: Learning Resources
 ### Quick References
 
 - [Scala Standard Library API](http://www.scala-lang.org/api/)
-- [Scala School!](http://twitter.github.com/scala_school/): A Scala tutorial by Twitter
+- [Scala School!](http://twitter.github.io/scala_school/): A Scala tutorial by Twitter
 - [A Tour of Scala](https://docs.scala-lang.org/tour/tour-of-scala.html): Tutorial indroducing the main concepts of Scala
 - [Scala Overview on StackOverflow](http://stackoverflow.com/tags/scala/info): A list of useful questions sorted by topic
 


### PR DESCRIPTION
Replaced mentions of twitter.github.com around this repository to twitter.github.io

I have also reported the domain change to https://github.com/twitter/scala_school/issues/223